### PR TITLE
Use last commit author name as CircleCI username

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -5,7 +5,7 @@ set -e
 
 git config --global push.default simple
 git config --global user.email $(git --no-pager show -s --format='%ae' HEAD)
-git config --global user.name $CIRCLE_USERNAME
+git config --global user.name $(git --no-pager show -s --format='%an' HEAD)
 
 git clone -q --branch=gh-pages $CIRCLE_REPOSITORY_URL $DEPLOY_DIR
 


### PR DESCRIPTION
The [most recent push](https://circleci.com/gh/cpssd-students/cpssd.net/19) with CircleCI failed because the `$CIRCLE_USERNAME` var was empty.

This changes the push name to be the commit author, similar to how the email is set. 
(Note the format is `%an` vs `%ae` for the email, they're not identical)
